### PR TITLE
Add missing sanitizer symbolizer paths to clang ENV

### DIFF
--- a/lib/compilers/clang.ts
+++ b/lib/compilers/clang.ts
@@ -128,7 +128,11 @@ export class ClangCompiler extends BaseCompiler {
         if (this.asanSymbolizerPath) {
             executeParameters.env = {
                 ASAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
+                LSAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
                 MSAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
+                RTSAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
+                TSAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
+                UBSAN_SYMBOLIZER_PATH: this.asanSymbolizerPath,
                 ...executeParameters.env,
             };
         }


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This commit adds some of the other `XSAN_SYMBOLIZER_PATH` to be explicitly defined.

This is trying to solve the problem where the (brand new) realtime sanitizer stack looks like this (ugly, unsymbolized):
https://godbolt.org/z/9sEfWfKqh

```
Real-time violation: intercepted call to real-time unsafe function `malloc` in real-time context! Stack trace:
    #0 0x64c376bf989c  (/app/output.s+0x789c)
    #1 0x64c376bf96d2  (/app/output.s+0x76d2)
    #2 0x64c376bfa415  (/app/output.s+0x8415)
    #3 0x7d6bd33130bb  (/opt/compiler-explorer/gcc-snapshot/lib64/libstdc++.so.6+0xc50bb) (BuildId: a13460978c796b26d549743185c1dad8fbc8d116)
    #4 0x64c376c205b5  (/app/output.s+0x2e5b5)
    #5 0x64c376c203ef  (/app/output.s+0x2e3ef)
    #6 0x64c376c201aa  (/app/output.s+0x2e1aa)
    #7 0x64c376c20022  (/app/output.s+0x2e022)
    #8 0x64c376c1ff69  (/app/output.s+0x2df69)
    #9 0x7d6bd2e29d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #10 0x7d6bd2e29e3f  (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #11 0x64c376bf94a4  (/app/output.s+0x74a4)
```

While asan has this (beautiful, symbolized):
https://godbolt.org/z/cvM8Gxr43
```
allocated by thread T0 here:
    #0 0x5c768b65f1fd in operator new(unsigned long) /root/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x5c768b6626ff in std::__new_allocator<int>::allocate(unsigned long, void const*) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/new_allocator.h:151:27
    #2 0x5c768b6622bf in std::allocator<int>::allocate(unsigned long) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/allocator.h:196:32
    #3 0x5c768b6622bf in std::allocator_traits<std::allocator<int>>::allocate(std::allocator<int>&, unsigned long) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/alloc_traits.h:614:20
    #4 0x5c768b6622bf in std::_Vector_base<int, std::allocator<int>>::_M_allocate(unsigned long) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/stl_vector.h:380:20
    #5 0x5c768b661e08 in void std::vector<int, std::allocator<int>>::_M_range_initialize<int const*>(int const*, int const*, std::forward_iterator_tag) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/stl_vector.h:1720:12
    #6 0x5c768b661a8d in std::vector<int, std::allocator<int>>::vector(std::initializer_list<int>, std::allocator<int> const&) /opt/compiler-explorer/gcc-snapshot/lib/gcc/x86_64-linux-gnu/15.0.0/../../../../include/c++/15.0.0/bits/stl_vector.h:682:2
    #7 0x5c768b661794 in main /app/example.cpp:5:21
    #8 0x7fae5cc29d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833
```

It is entirely possible that this is a problem with the sanitizer, and not compiler explorer, but I have a hunch this is in the right direction.